### PR TITLE
Add document revocation functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A decentralized document verification and storage system built on Stacks blockch
 - Track document history
 - Manage document access permissions
 - Support document metadata
+- Revoke documents
 
 ## Usage
 
@@ -23,6 +24,11 @@ A decentralized document verification and storage system built on Stacks blockch
 ### Verify a document
 ```clarity
 (contract-call? .docuchain verify-document "QmHash...")
+```
+
+### Revoke a document
+```clarity
+(contract-call? .docuchain revoke-document "QmHash...")
 ```
 
 ## Development

--- a/contracts/docuchain.clar
+++ b/contracts/docuchain.clar
@@ -5,6 +5,7 @@
 (define-constant err-not-found (err u404))
 (define-constant err-unauthorized (err u403))
 (define-constant err-already-exists (err u409))
+(define-constant err-invalid-status (err u400))
 
 ;; Data structures
 (define-map documents
@@ -60,6 +61,19 @@
     (map-set document-access
       { hash: hash, user: user }
       { can-read: can-read, can-update: can-update }
+    )
+    (ok true)
+  )
+)
+
+(define-public (revoke-document (hash (string-ascii 64)))
+  (let ((doc-info (get-document-info hash)))
+    (asserts! (is-eq tx-sender (get owner (unwrap! doc-info err-not-found))) err-unauthorized)
+    (map-set documents
+      { hash: hash }
+      (merge (unwrap! doc-info err-not-found)
+        { status: "revoked" }
+      )
     )
     (ok true)
   )

--- a/tests/docuchain_test.ts
+++ b/tests/docuchain_test.ts
@@ -80,3 +80,27 @@ Clarinet.test({
     });
   },
 });
+
+Clarinet.test({
+  name: "Can revoke a document",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    const wallet_1 = accounts.get("wallet_1")!;
+    
+    let block = chain.mineBlock([
+      Tx.contractCall("docuchain", "store-document", [
+        types.ascii("QmHash123"),
+        types.ascii("Test Document"),
+        types.ascii("application/pdf")
+      ], wallet_1.address),
+      Tx.contractCall("docuchain", "revoke-document", [
+        types.ascii("QmHash123")
+      ], wallet_1.address),
+      Tx.contractCall("docuchain", "verify-document", [
+        types.ascii("QmHash123")
+      ], wallet_1.address)
+    ]);
+    
+    assertEquals(block.receipts[1].result, '(ok true)');
+    assertEquals(block.receipts[2].result.expectOk().expectTuple().status, 'revoked');
+  },
+});


### PR DESCRIPTION
This PR adds the ability for document owners to revoke documents in the DocuChain system.

Changes made:
1. Added a new `revoke-document` public function that allows document owners to mark their documents as revoked
2. Added corresponding test cases to verify the revocation functionality
3. Updated README to document the new feature

The revocation feature is important for cases where:
- Documents become obsolete
- Documents contain errors
- Documents need to be invalidated for legal or compliance reasons

All changes are backward compatible and existing functionality remains unchanged.
The document status is tracked in the existing documents map, using a new "revoked" status value.